### PR TITLE
Unified test call, so it also transmits the password hash + logging

### DIFF
--- a/src/fr/s13d/photobackup/PBMediaSender.java
+++ b/src/fr/s13d/photobackup/PBMediaSender.java
@@ -24,6 +24,7 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.graphics.LinearGradient;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Build;
@@ -194,7 +195,6 @@ public class PBMediaSender {
                 .build();
         final Request request = makePostRequest(requestBody, TEST_PATH);
         Log.i(LOG_TAG, "Initiating test call to " + request.url());
-        Log.i(LOG_TAG, prefs.getString(PBServerPreferenceFragment.PREF_SERVER_PASS_HASH, ""));
         okClient.newCall(request).enqueue(new Callback() {
             @Override
             public void onResponse(Call call, Response response) throws IOException {


### PR DESCRIPTION
I've noticed, that the test call didn't send the password with the POST body but as a header. 
I've adjusted the call so it is now the same userAgent, and also extracted the request building into a method.

The Test onFailure can also pass the IO exception message to the toast, it might be useful, like Network unreachable or Timeout etc.

Note: I didn't do Java programming since 5 years or so, so please tell me, if there is something wrong :-D 

(I also had to rebase my code, as I also fixed some of the same things, that you pushed recently)
