### PR TITLE
Response code 409 = already uploaded also note as success (fixes #24)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ android:
     - android-21
 
 before_script:
-  - gradle wrapper --gradle-version 2.4
+  - gradle wrapper --gradle-version 2.10
   - chmod +x gradlew
   # Create and start emulator
   - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ android:
     - android-21
 
 before_script:
-  - gradle wrapper --gradle-version 2.10
+  - gradle wrapper --gradle-version 2.1
   - chmod +x gradlew
   # Create and start emulator
   - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI

--- a/src/fr/s13d/photobackup/PBMediaSender.java
+++ b/src/fr/s13d/photobackup/PBMediaSender.java
@@ -207,7 +207,7 @@ public class PBMediaSender {
         okClient.newCall(request).enqueue(new Callback() {
             @Override
             public void onResponse(Call call, Response response) throws IOException {
-                if (response.code() == 200) {
+                if (response.isSuccessful() || response.code() == 409) {
                     testDidSucceed(toast);
                 } else {
                     testDidFail(toast, response.message());


### PR DESCRIPTION
- I've replaced the == 200 with the isSuccessful() from the Okclient (checks 200..299 status code)
- 409 = success

What do you think? Another option would be to keep book with the "alreadyUpload" and display it in the notification "5 photos uploaded, 2 failures, 3 already up...." (maybe also too long...)
