### PR TITLE
Increased Timeout from default 10 -> 30

### DIFF
--- a/src/fr/s13d/photobackup/PBMediaSender.java
+++ b/src/fr/s13d/photobackup/PBMediaSender.java
@@ -47,6 +47,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import fr.s13d.photobackup.interfaces.PBMediaSenderInterface;
 import fr.s13d.photobackup.preferences.PBPreferenceFragment;
@@ -64,7 +65,7 @@ public class PBMediaSender {
     private final SharedPreferences prefs;
     private final NotificationManager notificationManager;
     private final Notification.Builder builder;
-    private final OkHttpClient okClient = new OkHttpClient();
+    private final OkHttpClient okClient;
     private final String credentials;
     private static List<PBMediaSenderInterface> interfaces = new ArrayList<>();
     private static int successCount = 0;
@@ -72,6 +73,12 @@ public class PBMediaSender {
 
 
     public PBMediaSender(final Context context) {
+        okClient = new OkHttpClient.Builder()
+            .readTimeout(30, TimeUnit.SECONDS)
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
+            .build();
+
         this.context = context;
         this.notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         this.builder = new Notification.Builder(context);
@@ -160,7 +167,6 @@ public class PBMediaSender {
                 .addFormDataPart(UPFILE_PARAM, upfile.getName(), RequestBody.create(MEDIA_TYPE_JPG, upfile))
                 .build();
         final Request request = makePostRequest(requestBody);
-
         okClient.newCall(request).enqueue(new Callback() {
             @Override
             public void onResponse(Call call, Response response) throws IOException {


### PR DESCRIPTION
The default OKhttp client timeout for read/write/connect is each 10seconds. I've increased it to 30s each.

In my current place the internet is a little flaky sometimes, so some uploads fail occasionally.

I am not sure, if the write timeout should be even higher than that, like several minutes for making sure the files get uploaded properly.

e.g. https://github.com/square/retrofit/issues/1447
