### PR TITLE
Fixing squid: S2696 Instance methods should not write to "static" fields

### DIFF
--- a/src/fr/s13d/photobackup/PBMediaSender.java
+++ b/src/fr/s13d/photobackup/PBMediaSender.java
@@ -242,7 +242,7 @@ public class PBMediaSender {
         for (PBMediaSenderInterface senderInterface : interfaces) {
             senderInterface.onSendSuccess();
         }
-        successCount++;
+        incrementSuccessCount();
         updateNotificationText();
     }
 
@@ -257,7 +257,7 @@ public class PBMediaSender {
             e.printStackTrace();
 
         }
-        failureCount++;
+        incrementFailureCount();
         updateNotificationText();
     }
 
@@ -325,5 +325,10 @@ public class PBMediaSender {
 
         return s.substring(0, s.length() - count);
     }
-
+    private static void  incrementSuccessCount(){
+        successCount++;
+    }
+    private static void  incrementFailureCount(){
+        failureCount++;
+    }
 }

--- a/src/fr/s13d/photobackup/PBMediaStore.java
+++ b/src/fr/s13d/photobackup/PBMediaStore.java
@@ -52,22 +52,30 @@ public class PBMediaStore {
         picturesPreferences = context.getSharedPreferences(PhotoBackupPicturesSharedPreferences, Context.MODE_PRIVATE);
         picturesPreferencesEditor = picturesPreferences.edit();
         picturesPreferencesEditor.apply();
+        syncTask=new SyncMediaStoreTask();
     }
 
-
+    private static void setMediaListToNull(){
+        mediaList = null;
+    }
+    private static void setPicturesPreferencesToNull(){
+        picturesPreferences = null;
+    }
+    private static void setPicturesPreferencesEditorToNull(){
+        picturesPreferencesEditor = null;
+    }
     public void addInterface(PBMediaStoreInterface storeInterface) {
         interfaces.add(storeInterface);
     }
-
 
     public void close() {
         if (syncTask != null) {
             syncTask.cancel(true);
         }
 
-        mediaList = null;
-        picturesPreferences = null;
-        picturesPreferencesEditor = null;
+        setMediaListToNull();
+        setPicturesPreferencesToNull();
+        setPicturesPreferencesEditorToNull();
     }
 
 
@@ -122,12 +130,17 @@ public class PBMediaStore {
         if (syncTask != null) {
             syncTask.cancel(true);
         }
-        syncTask = new SyncMediaStoreTask();
-        syncTask.execute();
+        setSyncTask();
         Log.i(LOG_TAG, "Start SyncMediaStoreTask");
     }
 
-
+    private static  SyncMediaStoreTask getSyncMediaStoreTask(){
+        return syncTask;
+    }
+    private static void setSyncTask(){
+        syncTask=getSyncMediaStoreTask();
+        syncTask.execute();
+    }
     private class SyncMediaStoreTask extends AsyncTask<Void, Void, Void> {
 
         /////////////////////////////////

--- a/src/fr/s13d/photobackup/PBService.java
+++ b/src/fr/s13d/photobackup/PBService.java
@@ -68,13 +68,15 @@ public class PBService extends Service implements PBMediaStoreInterface, PBMedia
     public void onDestroy() {
         super.onDestroy();
         this.getApplicationContext().getContentResolver().unregisterContentObserver(newMediaContentObserver);
-        newMediaContentObserver = null;
+        setNewMediaContentObserverToNull();
         mediaStore.close();
         mediaStore = null;
 
         Log.i(LOG_TAG, "PhotoBackup service has stopped");
     }
-
+    private static void setNewMediaContentObserverToNull(){
+        newMediaContentObserver = null;
+    }
 
     @Override
     public int onStartCommand(final Intent intent, final int flags, final int startId) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2696 - “ Instance methods should not write to "static" fields”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2696
 Please let me know if you have any questions.
Fevzi Ozgul
