### PR TITLE
Fixing squid:S1148  Throwable.printStackTrace(...) should not be called

### DIFF
--- a/src/fr/s13d/photobackup/PBJournalActivity.java
+++ b/src/fr/s13d/photobackup/PBJournalActivity.java
@@ -31,9 +31,12 @@ import android.widget.Button;
 import android.widget.ListView;
 import android.widget.ToggleButton;
 
+import java.util.logging.Logger;
+
 
 public class PBJournalActivity extends ListActivity {
 
+    private static final Logger LOGGER = Logger.getLogger(PBJournalActivity.class.getName());
     private PBMediaSender mediaSender;
     private SharedPreferences preferences;
     private SharedPreferences.Editor preferencesEditor;
@@ -71,7 +74,7 @@ public class PBJournalActivity extends ListActivity {
                     builder.setNegativeButton(self.getString(R.string.cancel), null);
                     builder.create().show();
                 } catch(NullPointerException e) {
-                    e.printStackTrace();
+                   LOGGER.warning(e.toString());
                 }
             }
         });

--- a/src/fr/s13d/photobackup/PBMediaSender.java
+++ b/src/fr/s13d/photobackup/PBMediaSender.java
@@ -47,6 +47,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 
 import fr.s13d.photobackup.interfaces.PBMediaSenderInterface;
 import fr.s13d.photobackup.preferences.PBPreferenceFragment;
@@ -54,6 +55,7 @@ import fr.s13d.photobackup.preferences.PBServerPreferenceFragment;
 
 
 public class PBMediaSender {
+    private static final Logger LOGGER = Logger.getLogger(PBMediaSender.class.getName());
     private static final String LOG_TAG = "PBMediaSender";
     private final static String PASSWORD_PARAM = "password";
     private final static String UPFILE_PARAM = "upfile";
@@ -175,7 +177,7 @@ public class PBMediaSender {
 
             @Override
             public void onFailure(Call call, IOException e) {
-                e.printStackTrace();
+               LOGGER.warning(e.toString());
                 sendDidFail(media, e);
             }
         });
@@ -254,7 +256,7 @@ public class PBMediaSender {
             senderInterface.onSendFailure();
         }
         if (e != null) {
-            e.printStackTrace();
+            LOGGER.warning(e.toString());
 
         }
         failureCount++;

--- a/src/fr/s13d/photobackup/PBMediaStore.java
+++ b/src/fr/s13d/photobackup/PBMediaStore.java
@@ -30,11 +30,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Logger;
 
 import fr.s13d.photobackup.interfaces.PBMediaStoreInterface;
 
 public class PBMediaStore {
 
+    private static final Logger LOGGER = Logger.getLogger(PBMediaStore.class.getName());
     private static final String LOG_TAG = "PBMediaStore";
     private static Context context;
     private static List<PBMedia> mediaList;
@@ -146,7 +148,7 @@ public class PBMediaStore {
             try {
                 cursor = context.getContentResolver().query(uri, projection, null, null, "date_added DESC");
             } catch(SecurityException e) {
-                e.printStackTrace();
+               LOGGER.warning(e.toString());
             }
 
             // loop through them to sync

--- a/src/fr/s13d/photobackup/PBService.java
+++ b/src/fr/s13d/photobackup/PBService.java
@@ -29,12 +29,15 @@ import android.provider.MediaStore;
 import android.support.v4.content.LocalBroadcastManager;
 import android.widget.Toast;
 
+import java.util.logging.Logger;
+
 import fr.s13d.photobackup.interfaces.PBMediaSenderInterface;
 import fr.s13d.photobackup.interfaces.PBMediaStoreInterface;
 
 
 public class PBService extends Service implements PBMediaStoreInterface, PBMediaSenderInterface {
 
+    private static final Logger LOGGER = Logger.getLogger(PBService.class.getName());
 	private static final String LOG_TAG = "PBService";
     private static MediaContentObserver newMediaContentObserver;
     private PBMediaStore mediaStore;
@@ -179,7 +182,7 @@ public class PBService extends Service implements PBMediaStoreInterface, PBMedia
                 }
                 catch (Exception e) {
                     Log.e(LOG_TAG, "Upload failed :-(");
-                    e.printStackTrace();
+                    LOGGER.warning(e.toString());
                 }
             }
         }

--- a/src/fr/s13d/photobackup/preferences/PBPreferenceFragment.java
+++ b/src/fr/s13d/photobackup/preferences/PBPreferenceFragment.java
@@ -46,6 +46,7 @@ import android.widget.Toast;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.logging.Logger;
 
 import fr.s13d.photobackup.Log;
 import fr.s13d.photobackup.PBActivity;
@@ -60,6 +61,7 @@ public class PBPreferenceFragment extends PreferenceFragment
                                 implements SharedPreferences.OnSharedPreferenceChangeListener,
                                            PBMediaStoreInterface, PBMediaSenderInterface {
 
+    private static final Logger LOGGER = Logger.getLogger(PBPreferenceFragment.class.getName());
     private static final String LOG_TAG = "PBPreferenceFragment";
     private static PBPreferenceFragment self;
     private PBService currentService;
@@ -341,7 +343,7 @@ public class PBPreferenceFragment extends PreferenceFragment
                 uploadJournalPref.setEnabled(false);
             }
         } catch (IllegalStateException e) {
-            e.printStackTrace();
+            LOGGER.warning(e.toString());
         }
     }
 


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1148 - “Throwable.printStackTrace(...) should not be called”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1148
 Please let me know if you have any questions.
Fevzi Ozgul
