### PR TITLE
Fixing squid: S1118 Utility classes should not have public constructors

### DIFF
--- a/src/fr/s13d/photobackup/Log.java
+++ b/src/fr/s13d/photobackup/Log.java
@@ -19,8 +19,11 @@
 package fr.s13d.photobackup;
 
 
-final public class Log {
+public final  class Log {
 
+    private Log() throws InstantiationException{
+        throw new InstantiationException("This class is not meant to be instantiated!");
+    }
 	public static void d(String tag, String message) {
         if (BuildConfig.DEBUG) {
         	android.util.Log.d(tag, message);


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1118 - “Utility classes should not have public constructors ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1118
 Please let me know if you have any questions.
Fevzi Ozgul
