### PR TITLE
Fixes #35: Reverted some refactorings that broke the background task

### DIFF
--- a/src/fr/s13d/photobackup/PBMediaSender.java
+++ b/src/fr/s13d/photobackup/PBMediaSender.java
@@ -76,6 +76,7 @@ public class PBMediaSender {
         this.notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         this.prefs = PreferenceManager.getDefaultSharedPreferences(context);
         this.serverUrl = removeFinalSlashes(prefs.getString(PBServerPreferenceFragment.PREF_SERVER_URL, ""));
+        buildNotificationBuilder();
     }
 
 

--- a/src/fr/s13d/photobackup/PBMediaStore.java
+++ b/src/fr/s13d/photobackup/PBMediaStore.java
@@ -51,7 +51,7 @@ public class PBMediaStore {
         picturesPreferences = context.getSharedPreferences(PBApplication.PB_PICTURES_SHARED_PREFS, Context.MODE_PRIVATE);
         picturesPreferencesEditor = picturesPreferences.edit();
         picturesPreferencesEditor.apply();
-        syncTask=new SyncMediaStoreTask();
+
     }
 
 
@@ -133,7 +133,9 @@ public class PBMediaStore {
         if (syncTask != null) {
             syncTask.cancel(true);
         }
-        setSyncTask();
+
+        syncTask=new SyncMediaStoreTask();
+        syncTask.execute();
         Log.i(LOG_TAG, "Start SyncMediaStoreTask");
     }
 
@@ -141,13 +143,6 @@ public class PBMediaStore {
     private static  SyncMediaStoreTask getSyncMediaStoreTask(){
         return syncTask;
     }
-
-
-    private static void setSyncTask(){
-        syncTask=getSyncMediaStoreTask();
-        syncTask.execute();
-    }
-
 
     private class SyncMediaStoreTask extends AsyncTask<Void, Void, Void> {
 


### PR DESCRIPTION
Don't know why, but initializing the task in the constructor broke the background task; From the log one can see that the task was started, but doInBackground was never called after that.

Anyway, I don't exactly see the point in the refactorings before :-)  
`setPicturesPreferencesToNull();` is better than `picturesPreferences = null;`? Is this the Java's community preferred way? 🙈 
