### PR TITLE
Saving the error message per photo and display that under the file na…

### DIFF
--- a/res/layout/list_row.xml
+++ b/res/layout/list_row.xml
@@ -2,8 +2,8 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/list_image"
     android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    android:padding="5dip" >
+    android:layout_height="wrap_content"
+    android:padding="5dip">
 
     <!-- Thumbnail image on the left -->
     <ImageView
@@ -38,5 +38,15 @@
         android:layout_toStartOf="@id/state"
         android:textAppearance="@android:style/TextAppearance.Small"
         android:text="@string/name" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="@android:style/TextAppearance.Small"
+        android:text="Foobar"
+        android:id="@+id/hint"
+        android:layout_below="@+id/state"
+        android:layout_alignLeft="@+id/filename"
+        android:layout_alignStart="@+id/filename" />
 
 </RelativeLayout>

--- a/src/fr/s13d/photobackup/PBJournalAdapter.java
+++ b/src/fr/s13d/photobackup/PBJournalAdapter.java
@@ -118,13 +118,17 @@ public class PBJournalAdapter extends BaseAdapter implements Filterable, Handler
             textView.setText(R.string.journal_error);
         }
 
-		// indicator
+        final TextView errorView = (TextView)view.findViewById(R.id.hint);
+        errorView.setText("");
+
+        // indicator
         final ImageView imageView = (ImageView)view.findViewById(R.id.state);
         if (media.getState() == PBMedia.PBMediaState.WAITING) {
             imageView.setImageResource(android.R.drawable.presence_away);
         } else if (media.getState() == PBMedia.PBMediaState.SYNCED) {
             imageView.setImageResource(android.R.drawable.presence_online);
         } else if (media.getState() == PBMedia.PBMediaState.ERROR) {
+            errorView.setText(media.getErrorMessage());
             imageView.setImageResource(android.R.drawable.presence_busy);
         }
 

--- a/src/fr/s13d/photobackup/PBMedia.java
+++ b/src/fr/s13d/photobackup/PBMedia.java
@@ -29,6 +29,7 @@ public class PBMedia implements Serializable {
     final private int id;
     final private String path;
     final private long dateAdded;
+    private String errorMessage;
     private PBMediaState state;
     Context context;
     public enum PBMediaState { WAITING, SYNCED, ERROR }
@@ -47,6 +48,7 @@ public class PBMedia implements Serializable {
         String stateString = preferences.getString(String.valueOf(this.id), PBMedia.PBMediaState.WAITING.name());
         this.state = PBMedia.PBMediaState.valueOf(stateString);
         this.context = context;
+        this.errorMessage = "";
     }
 
 
@@ -75,6 +77,10 @@ public class PBMedia implements Serializable {
     public long getDateAdded() {
         return this.dateAdded;
     }
+
+    public String getErrorMessage() { return this.errorMessage; }
+
+    public void setErrorMessage(String newMessage) { this.errorMessage = newMessage; }
 
     public PBMediaState getState() {
         return this.state;

--- a/src/fr/s13d/photobackup/PBMediaSender.java
+++ b/src/fr/s13d/photobackup/PBMediaSender.java
@@ -76,6 +76,7 @@ public class PBMediaSender {
         this.notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         this.prefs = PreferenceManager.getDefaultSharedPreferences(context);
         this.serverUrl = removeFinalSlashes(prefs.getString(PBServerPreferenceFragment.PREF_SERVER_URL, ""));
+        buildNotificationBuilder();
     }
 
 
@@ -244,6 +245,7 @@ public class PBMediaSender {
     private void sendDidSucceed(final PBMedia media) {
         builder.setSmallIcon(R.drawable.ic_done_white_48dp);
         media.setState(PBMedia.PBMediaState.SYNCED);
+        media.setErrorMessage("");
         for (PBMediaSenderInterface senderInterface : interfaces) {
             senderInterface.onSendSuccess();
         }
@@ -255,6 +257,7 @@ public class PBMediaSender {
     private void sendDidFail(final PBMedia media, final Throwable e) {
         builder.setSmallIcon(R.drawable.ic_error_outline_white_48dp);
         media.setState(PBMedia.PBMediaState.ERROR);
+        media.setErrorMessage(e.getLocalizedMessage());
         for (PBMediaSenderInterface senderInterface : interfaces) {
             senderInterface.onSendFailure();
         }


### PR DESCRIPTION
![large_screenshot_20160520-230030](https://cloud.githubusercontent.com/assets/147175/15432026/0fcd2ec8-1edf-11e6-98c0-03fcb23d10cb.png)
- In case of upload error, save the error message in a private field of PBMedia. 
- Displaying that on the upload journal

I am not a layout expert, if you have any idea on how to improve the design/layout, I am happy to hear!
