### PR TITLE
Retry All failed button in Upload journal

### DIFF
--- a/res/layout/activity_journal.xml
+++ b/res/layout/activity_journal.xml
@@ -61,10 +61,28 @@
         android:layout_height="1px"
         android:background="?android:attr/listDivider" />
 
-    <ListView
-        android:id="@android:id/list"
+    <FrameLayout
         android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
-        android:text="@string/journal_title" />
+        android:layout_height="match_parent">
+
+        <ListView
+            android:id="@android:id/list"
+            android:layout_width="fill_parent"
+            android:layout_height="match_parent"
+            android:text="@string/journal_title" />
+
+        <Button
+            style="?android:attr/buttonStyleSmall"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/retry_all_button_text"
+            android:id="@+id/button"
+            android:drawableLeft="@android:drawable/ic_menu_rotate"
+            android:drawableStart="@android:drawable/presence_online"
+            android:drawablePadding="0dip"
+            android:layout_gravity="right|bottom"
+            android:onClick="retryAll" />
+
+    </FrameLayout>
 
 </LinearLayout>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -43,7 +43,7 @@ Um deinen eigenen Server zu installieren und konfigurieren, schaue bitte hier:</
     <string name="toast_test_configuration">Server testen</string>
     <string name="toast_urisyntaxexception">Die Serveradresse ist ungültig.</string>
     <string name="select_folder">Ordner zur Sicherung auswählen</string>
-    <string name="retry_all_text">Alle Dateien erneut hochladen, die noch nicht als Gespeichert markiert sind. (Maximal 100 pro Vorgang)</string>
+    <string name="retry_all_text">Alle Dateien erneut hochladen, die noch nicht als Gespeichert markiert sind. (Maximal %d pro Vorgang, keine älteren als 6 Monate)</string>
     <string name="retry_all_title">Ungespeicherte erneut hochladen</string>
     <string name="retry_all_button_text">Erneut versuchen</string>
 </resources>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -43,4 +43,7 @@ Um deinen eigenen Server zu installieren und konfigurieren, schaue bitte hier:</
     <string name="toast_test_configuration">Server testen</string>
     <string name="toast_urisyntaxexception">Die Serveradresse ist ungültig.</string>
     <string name="select_folder">Ordner zur Sicherung auswählen</string>
+    <string name="retry_all_text">Alle Dateien erneut hochladen, die noch nicht als Gespeichert markiert sind. (Maximal 100 pro Vorgang)</string>
+    <string name="retry_all_title">Ungespeicherte erneut hochladen</string>
+    <string name="retry_all_button_text">Erneut versuchen</string>
 </resources>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -8,7 +8,7 @@ Um deinen eigenen Server zu installieren und konfigurieren, schaue bitte hier:</
     <string name="app_version">PhotoBackup Version %1$s</string>
     <string name="cancel">Abbrechen</string>
     <string name="info_conf">Informationen</string>
-    <string name="journal_backedup">Gespeichert</string>
+    <string name="journal_backedup">Fertig</string>
     <string name="journal_error">Fehler</string>
     <string name="journal_noaccess">Starte erst den Dienst um das Protokoll zu sehen</string>
     <string name="journal_title">Upload Protokoll</string>
@@ -42,4 +42,5 @@ Um deinen eigenen Server zu installieren und konfigurieren, schaue bitte hier:</
     <string name="toast_serverpassempty">Passwort darf nicht leer sein!</string>
     <string name="toast_test_configuration">Server testen</string>
     <string name="toast_urisyntaxexception">Die Serveradresse ist ungültig.</string>
+    <string name="select_folder">Ordner zur Sicherung auswählen</string>
 </resources>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -31,4 +31,6 @@
         <item>@string/not_only_recent_upload</item>
     </string-array>
 
+    <string-array name="empty_array"/>
+
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -64,6 +64,6 @@
 
     <string name="retry_all_button_text">Retry unsaved</string>
     <string name="retry_all_title">Retry all unsaved</string>
-    <string name="retry_all_text">Retry all media files that are currently not marked as "Saved" (Max. 100 at once).</string>
+    <string name="retry_all_text">Retry all media files that are currently not marked as "Saved" (Max. %d at once, not older than 6 months).</string>
 
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -60,5 +60,7 @@
     <string name="thumbnail_description">Thumbnail of the photo</string>
     <string name="manual_backup_title">Manual backup</string>
     <string name="manual_backup_message">Save this picture now!</string>
+    <string name="select_folder">Select photo folder to backup</string>
+
 
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -33,7 +33,7 @@
     <string name="toast_configuration_ko">Server test failed, please verify your configuration.</string>
     <string name="toast_permission_not_granted">PhotoBackup cannot work properly without the permission to read your pictures.</string>
 
-    <string name="info_conf">Informations</string>
+    <string name="info_conf">Information</string>
     <string name="journal_title">Upload journal</string>
     <string name="journal_noaccess">Launch the service to access the journal.</string>
     <string name="journal_backedup">Saved</string>
@@ -62,5 +62,8 @@
     <string name="manual_backup_message">Save this picture now!</string>
     <string name="select_folder">Select photo folder to backup</string>
 
+    <string name="retry_all_button_text">Retry unsaved</string>
+    <string name="retry_all_title">Retry all unsaved</string>
+    <string name="retry_all_text">Retry all media files that are currently not marked as "Saved" (Max. 100 at once).</string>
 
 </resources>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -37,6 +37,16 @@
         android:entryValues="@array/pref_upload_values"
         android:defaultValue="@string/only_recent_upload" />
 
+    <MultiSelectListPreference
+        android:key="PREF_BUCKETS"
+        android:title="@string/select_folder"
+        android:summary=""
+        android:entries="@array/empty_array"
+        android:defaultValue="@array/empty_array"
+        android:enabled="false"
+        android:entryValues="@array/empty_array"
+        />
+
     <PreferenceCategory
         android:title="@string/info_conf"
         android:key="info_conf">

--- a/src/fr/s13d/photobackup/PBJournalActivity.java
+++ b/src/fr/s13d/photobackup/PBJournalActivity.java
@@ -130,29 +130,32 @@ public class PBJournalActivity extends ListActivity implements PBMediaSenderInte
     // buttons call //
     //////////////////
     public void clickOnSaved(View v) {
-        Log.i("PBJournalActivity", "clickOnSaved");
+        Log.i(LOG_TAG, "clickOnSaved");
         ToggleButton btn = (ToggleButton)v;
         preferencesEditor.putBoolean(PBMedia.PBMediaState.SYNCED.name(), btn.isChecked()).apply();
         adapter.getFilter().filter(null);
     }
 
     public void retryAll(View v){
-        Log.i("PBJournalActivity", "retryAll");
+        Log.i(LOG_TAG, "retryAll");
+
+        final int maxPics = 100;
 
         final Activity self = this;
         final AlertDialog.Builder builder = new AlertDialog.Builder(self);
-        builder.setMessage(self.getResources().getString(R.string.retry_all_title))
-                .setTitle(self.getResources().getString(R.string.retry_all_text));
+        builder.setTitle(self.getResources().getString(R.string.retry_all_title))
+                .setMessage(self.getResources().getString(R.string.retry_all_text, maxPics));
 
         builder.setPositiveButton("OK", new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int id) {
 
-                int count = 100;
+                int count = maxPics;
                 List<PBMedia> allMedia = PBActivity.getMediaStore().getMedias();
                 for (PBMedia media: allMedia){
-                     if(media.getState() == PBMedia.PBMediaState.ERROR || media.getState() == PBMedia.PBMediaState.WAITING) {
+                     // only save images younger than 6 months + not green yet
+                     if (media.isUnsaved() && media.getAge() < 60 * 60 * 24 * 30 * 6) {
                          getMediaSender().send(media, true);
-                         if( (count -= 1) == 0) {
+                         if ((count -= 1) == 0) {
                              break;
                          }
                      }

--- a/src/fr/s13d/photobackup/PBJournalActivity.java
+++ b/src/fr/s13d/photobackup/PBJournalActivity.java
@@ -30,6 +30,8 @@ import android.widget.AdapterView;
 import android.widget.ListView;
 import android.widget.ToggleButton;
 
+import java.util.List;
+
 import fr.s13d.photobackup.interfaces.PBMediaSenderInterface;
 
 
@@ -134,6 +136,35 @@ public class PBJournalActivity extends ListActivity implements PBMediaSenderInte
         adapter.getFilter().filter(null);
     }
 
+    public void retryAll(View v){
+        Log.i("PBJournalActivity", "retryAll");
+
+        final Activity self = this;
+        final AlertDialog.Builder builder = new AlertDialog.Builder(self);
+        builder.setMessage(self.getResources().getString(R.string.retry_all_title))
+                .setTitle(self.getResources().getString(R.string.retry_all_text));
+
+        builder.setPositiveButton("OK", new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int id) {
+
+                int count = 100;
+                List<PBMedia> allMedia = PBActivity.getMediaStore().getMedias();
+                for (PBMedia media: allMedia){
+                     if(media.getState() == PBMedia.PBMediaState.ERROR || media.getState() == PBMedia.PBMediaState.WAITING) {
+                         getMediaSender().send(media, true);
+                         if( (count -= 1) == 0) {
+                             break;
+                         }
+                     }
+                }
+            }
+        });
+        builder.setNegativeButton(self.getString(R.string.cancel), null);
+        builder.create().show();
+
+
+        //getMediaSender().send(media, true);
+    }
 
     public void clickOnWaiting(View v) {
         Log.i("PBJournalActivity", "clickOnWaiting");

--- a/src/fr/s13d/photobackup/PBMedia.java
+++ b/src/fr/s13d/photobackup/PBMedia.java
@@ -60,13 +60,23 @@ public class PBMedia implements Serializable {
     public String toString() {
         return "PBMedia: " + this.path;
     }
-
-
     /////////////////////////////////////////
     // Getters/Setters are the Java fun... //
     /////////////////////////////////////////
     public int getId() {
         return this.id;
+    }
+
+    public boolean isUnsaved() {
+        return state == PBMedia.PBMediaState.ERROR || state == PBMedia.PBMediaState.WAITING;
+    }
+
+    /**
+     * Age of media
+     * @return age in seconds
+     */
+    public long getAge() {
+        return System.currentTimeMillis() / 1000 - dateAdded;
     }
 
     public String getPath() {

--- a/src/fr/s13d/photobackup/PBMediaSender.java
+++ b/src/fr/s13d/photobackup/PBMediaSender.java
@@ -137,7 +137,6 @@ public class PBMediaSender {
                 } finally {
                     response.body().close();
                 }
-                response.body().close();
             }
 
             @Override
@@ -176,7 +175,6 @@ public class PBMediaSender {
                 } finally {
                     response.body().close();
                 }
-                response.body().close();
             }
 
             @Override

--- a/src/fr/s13d/photobackup/PBMediaSender.java
+++ b/src/fr/s13d/photobackup/PBMediaSender.java
@@ -203,7 +203,6 @@ public class PBMediaSender {
         return requestBuilder.build();
     }
 
-
     /////////////////////
     // Private methods //
     /////////////////////

--- a/src/fr/s13d/photobackup/PBMediaSender.java
+++ b/src/fr/s13d/photobackup/PBMediaSender.java
@@ -129,7 +129,7 @@ public class PBMediaSender {
             public void onResponse(Call call, Response response) throws IOException {
                 try {
                     Log.i(LOG_TAG, "Get response with code " + response.code());
-                    if (response.code() == 200) {
+                    if (response.isSuccessful() || response.code() == 409) {
                         sendDidSucceed(media);
                     } else {
                         sendDidFail(media, new Throwable(response.message()));
@@ -168,7 +168,7 @@ public class PBMediaSender {
             @Override
             public void onResponse(Call call, Response response) throws IOException {
                 try {
-                    if (response.isSuccessful() || response.code() == 409) {
+                    if (response.isSuccessful()) {
                         testDidSucceed(toast);
                     } else {
                         testDidFail(toast, response.message());

--- a/src/fr/s13d/photobackup/PBMediaSender.java
+++ b/src/fr/s13d/photobackup/PBMediaSender.java
@@ -100,7 +100,7 @@ public class PBMediaSender {
         String uploadRecentOnlyString = prefs.getString(PBPreferenceFragment.PREF_RECENT_UPLOAD_ONLY,
                 context.getResources().getString(R.string.only_recent_upload_default));
         Boolean uploadRecentOnly = uploadRecentOnlyString.equals(context.getResources().getString(R.string.only_recent_upload));
-        Boolean recentPicture = (System.currentTimeMillis() / 1000 - media.getDateAdded()) < 600;
+        Boolean recentPicture = media.getAge() < 600;
 
         // test to send or not
         if (manual || (!wifiOnly || onWifi) && (!uploadRecentOnly || recentPicture)) {

--- a/src/fr/s13d/photobackup/PBMediaSender.java
+++ b/src/fr/s13d/photobackup/PBMediaSender.java
@@ -127,11 +127,15 @@ public class PBMediaSender {
         getOkClient().newCall(request).enqueue(new Callback() {
             @Override
             public void onResponse(Call call, Response response) throws IOException {
-                Log.i(LOG_TAG, "Get response with code " + response.code());
-                if (response.code() == 200) {
-                    sendDidSucceed(media);
-                } else {
-                    sendDidFail(media, new Throwable(response.message()));
+                try {
+                    Log.i(LOG_TAG, "Get response with code " + response.code());
+                    if (response.code() == 200) {
+                        sendDidSucceed(media);
+                    } else {
+                        sendDidFail(media, new Throwable(response.message()));
+                    }
+                } finally {
+                    response.body().close();
                 }
                 response.body().close();
             }
@@ -163,10 +167,14 @@ public class PBMediaSender {
         getOkClient().newCall(request).enqueue(new Callback() {
             @Override
             public void onResponse(Call call, Response response) throws IOException {
-                if (response.isSuccessful() || response.code() == 409) {
-                    testDidSucceed(toast);
-                } else {
-                    testDidFail(toast, response.message());
+                try {
+                    if (response.isSuccessful() || response.code() == 409) {
+                        testDidSucceed(toast);
+                    } else {
+                        testDidFail(toast, response.message());
+                    }
+                } finally {
+                    response.body().close();
                 }
                 response.body().close();
             }

--- a/src/fr/s13d/photobackup/PBMediaStore.java
+++ b/src/fr/s13d/photobackup/PBMediaStore.java
@@ -18,6 +18,7 @@
  */
 package fr.s13d.photobackup;
 
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.database.Cursor;
@@ -42,6 +43,8 @@ public class PBMediaStore {
     private static SyncMediaStoreTask syncTask;
     private static SharedPreferences picturesPreferences;
     private static SharedPreferences.Editor picturesPreferencesEditor;
+    public static final String PhotoBackupPicturesSharedPreferences = "PhotoBackupPicturesSharedPreferences";
+    private static PBMediaStoreQueries queries;
     private List<PBMediaStoreInterface> interfaces = new ArrayList<>();
 
 
@@ -51,7 +54,7 @@ public class PBMediaStore {
         picturesPreferences = context.getSharedPreferences(PBApplication.PB_PICTURES_SHARED_PREFS, Context.MODE_PRIVATE);
         picturesPreferencesEditor = picturesPreferences.edit();
         picturesPreferencesEditor.apply();
-
+        queries = new PBMediaStoreQueries(context);
     }
 
 
@@ -65,6 +68,14 @@ public class PBMediaStore {
         picturesPreferencesEditor = null;
     }
 
+    public PBMedia getLastMediaInStore() {
+        int id = queries.getLastMediaIdInStore();
+        return getMedia(id);
+    }
+
+    public PBMediaStoreQueries getQueries() {
+        return queries;
+    }
 
     public void addInterface(PBMediaStoreInterface storeInterface) {
         interfaces.add(storeInterface);
@@ -83,27 +94,30 @@ public class PBMediaStore {
 
 
     public PBMedia getMedia(int id) {
-
         PBMedia media = null;
-        if (id != 0) {
-            final Cursor cursor = context.getContentResolver().query(uri, null, "_id = " + id, null, null);
-            if (cursor != null && cursor.moveToFirst()) {
-                media = new PBMedia(context, cursor);
+        if (id == 0) {
+            return null;
+        }
+        Cursor cursor = queries.getMediaById(id);
+        if (cursor == null) {
+            Log.i(LOG_TAG, "Photo not returned. Probably filtered by Bucket or deleted");
+            return null;
+        }
+        Integer idCol = cursor.getColumnIndex(MediaStore.Images.Media.BUCKET_ID);
+        queries.isSelectedBucket(cursor.getString(idCol));
 
-                try {
-                    String stateString = picturesPreferences.getString(String.valueOf(media.getId()), PBMedia.PBMediaState.WAITING.name());
-                    media.setState(PBMedia.PBMediaState.valueOf(stateString));
-                }
-                catch (Exception e) {
-                    Log.e(LOG_TAG, "Explosion!!");
-                }
-            }
 
-            if (cursor != null && !cursor.isClosed()) {
-                cursor.close();
-            }
+        media = new PBMedia(context, cursor);
+        try {
+            String stateString = picturesPreferences.getString(String.valueOf(media.getId()), PBMedia.PBMediaState.WAITING.name());
+            media.setState(PBMedia.PBMediaState.valueOf(stateString));
+        } catch (Exception e) {
+            Log.e(LOG_TAG, "Explosion!!");
         }
 
+        if (!cursor.isClosed()) {
+            cursor.close();
+        }
         return media;
     }
 
@@ -113,17 +127,6 @@ public class PBMediaStore {
     }
 
 
-    public PBMedia getLastMediaInStore() {
-        int id = 0;
-        final String[] projection = new String[] { "_id" };
-        final Cursor cursor = context.getContentResolver().query(uri, projection, null, null, "date_added DESC");
-        if (cursor != null && cursor.moveToFirst()) {
-            int idColumn = cursor.getColumnIndexOrThrow("_id");
-            id = cursor.getInt(idColumn);
-            cursor.close();
-        }
-        return getMedia(id);
-    }
 
 
     /////////////////////////////////
@@ -153,13 +156,7 @@ public class PBMediaStore {
             Set<String> inCursor = new HashSet<>();
 
             // Get all pictures on device
-            final String[] projection = new String[] { "_id", "_data", "date_added" };
-            Cursor cursor = null;
-            try {
-                cursor = context.getContentResolver().query(uri, projection, null, null, "date_added DESC");
-            } catch(SecurityException e) {
-               Log.w(LOG_TAG, e.toString());
-            }
+            Cursor cursor = queries.getAllMedia();
 
             // loop through them to sync
             PBMedia media;

--- a/src/fr/s13d/photobackup/PBMediaStore.java
+++ b/src/fr/s13d/photobackup/PBMediaStore.java
@@ -99,7 +99,7 @@ public class PBMediaStore {
         }
         Cursor cursor = queries.getMediaById(id);
         if (cursor == null) {
-            Log.i(LOG_TAG, "Photo not returned. Probably filtered by Bucket or deleted");
+            Log.e(LOG_TAG, "Photo not returned. Probably filtered by Bucket or deleted");
             return null;
         }
         Integer idCol = cursor.getColumnIndex(MediaStore.Images.Media.BUCKET_ID);

--- a/src/fr/s13d/photobackup/PBMediaStore.java
+++ b/src/fr/s13d/photobackup/PBMediaStore.java
@@ -18,7 +18,6 @@
  */
 package fr.s13d.photobackup;
 
-import android.content.ContentResolver;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.database.Cursor;

--- a/src/fr/s13d/photobackup/PBMediaStoreQueries.java
+++ b/src/fr/s13d/photobackup/PBMediaStoreQueries.java
@@ -93,7 +93,6 @@ public class PBMediaStoreQueries {
             id = cursor.getInt(idColumn);
             int bucketColumn = cursor.getColumnIndex(MediaStore.Images.Media.BUCKET_ID);
             bucketId = cursor.getString(bucketColumn);
-            Log.i(LOG_TAG, "BucketId: " + cursor.getString(bucketColumn) );
         }
         closeCursor(cursor);
         isSelectedBucket(bucketId);
@@ -149,8 +148,6 @@ public class PBMediaStoreQueries {
                 bucket = cur.getString(bucketColumn);
                 id = cur.getString(bucketIdColumn);
                 bucketCount = cur.getString(bucketCountColumn);
-
-                Log.d(LOG_TAG, "Bucket=" + bucket + ", count=" + bucketCount);
                 imageBuckets.put(id, bucket + " (" + bucketCount + ")");
             } while (cur.moveToNext());
         }

--- a/src/fr/s13d/photobackup/PBMediaStoreQueries.java
+++ b/src/fr/s13d/photobackup/PBMediaStoreQueries.java
@@ -24,6 +24,7 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.preference.PreferenceManager;
 import android.provider.MediaStore;
+import android.text.TextUtils;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -54,7 +55,6 @@ public class PBMediaStoreQueries {
         Log.d(LOG_TAG, "Checking if " + bucketId + " is selected by user..");
 
         for (String bucket: buckets) {
-            Log.d(LOG_TAG, "Selected bucket: " + bucket);
             if(bucket.equals(bucketId)) {
                 Log.d(LOG_TAG, "Is selected bucket! Continuing");
                 return true;
@@ -65,10 +65,18 @@ public class PBMediaStoreQueries {
     }
 
     public Cursor getAllMedia() {
+        String where;
         Cursor cursor = null;
         final String[] projection = new String[] { "_id", "_data", "date_added" };
+        Set<String> buckets = prefs.getStringSet(PBPreferenceFragment.PREF_BUCKETS, null);
+        if (buckets != null && buckets.size() > 0) {
+            String args = TextUtils.join(", ", buckets);
+            where = "bucket_id in (" + args + ")";
+        } else {
+            where = null;
+        }
         try {
-            cursor = context.getContentResolver().query(uri, projection, null, null, "date_added DESC");
+            cursor = context.getContentResolver().query(uri, projection, where, null, "date_added DESC");
         } catch(SecurityException e) {
             e.printStackTrace();
         }

--- a/src/fr/s13d/photobackup/PBMediaStoreQueries.java
+++ b/src/fr/s13d/photobackup/PBMediaStoreQueries.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (C) 2013-2015 Stéphane Péchard.
+ *
+ * This file is part of PhotoBackup.
+ *
+ * PhotoBackup is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PhotoBackup is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package fr.s13d.photobackup;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.database.Cursor;
+import android.net.Uri;
+import android.preference.PreferenceManager;
+import android.provider.MediaStore;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Set;
+import java.util.SortedMap;
+
+import fr.s13d.photobackup.preferences.PBPreferenceFragment;
+
+
+public class PBMediaStoreQueries {
+
+    private static final String LOG_TAG = "PBMediaStoreQueries";
+    private static String where;
+    private static Context context;
+    private static final Uri uri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+    private final SharedPreferences prefs;
+
+
+    public PBMediaStoreQueries(Context theContext) {
+        context = theContext;
+        HashMap<String, String> bucketNames = getAllBucketNames();
+        prefs = PreferenceManager.getDefaultSharedPreferences(context);
+    }
+
+    public boolean isSelectedBucket(String bucketId) {
+        Set<String> buckets = prefs.getStringSet(PBPreferenceFragment.PREF_BUCKETS, null);
+        // User has selected nothing - all buckets ok!
+        if (buckets == null || buckets.size() == 0) {
+            return true;
+        }
+        Log.d(LOG_TAG, "Checking if " + bucketId + " is selected by user..");
+
+        for (String bucket: buckets) {
+            Log.d(LOG_TAG, "Selected bucket: " + bucket);
+            if(bucket.equals(bucketId)) {
+                Log.d(LOG_TAG, "Is selected bucket! Continuing");
+                return true;
+            }
+        };
+        Log.i(LOG_TAG, "Is not in selected buckets - Ignoring");
+        return false;
+    }
+
+    public Cursor getAllMedia() {
+        Cursor cursor = null;
+        final String[] projection = new String[] { "_id", "_data", "date_added" };
+        try {
+            cursor = context.getContentResolver().query(uri, projection, where, null, "date_added DESC");
+        } catch(SecurityException e) {
+            e.printStackTrace();
+        }
+        return cursor;
+    }
+
+    public Integer getLastMediaIdInStore() {
+        int id = 0;
+        String bucketId = "";
+        final String[] projection = new String[] { "_id", MediaStore.Images.Media.BUCKET_ID };
+        final Cursor cursor = context.getContentResolver().query(uri, projection, null, null, "date_added DESC");
+        if (cursor != null && cursor.moveToFirst()) {
+            int idColumn = cursor.getColumnIndexOrThrow("_id");
+            id = cursor.getInt(idColumn);
+            int bucketColumn = cursor.getColumnIndex(MediaStore.Images.Media.BUCKET_ID);
+            bucketId = cursor.getString(bucketColumn);
+            Log.i(LOG_TAG, "BucketId: " + cursor.getString(bucketColumn) );
+        }
+        closeCursor(cursor);
+        isSelectedBucket(bucketId);
+        return id;
+    }
+
+    public Cursor getMediaById(Integer id) {
+        String localWhere = "_id = " + id;
+        final Cursor cursor = context.getContentResolver().query(uri, null, localWhere, null, null);
+        if (cursor != null && cursor.moveToFirst()) {
+            return cursor;
+        } else {
+            return null;
+        }
+    }
+    public LinkedHashMap<String,String> getAllBucketNames() {
+        // which image properties are we querying
+        String[] PROJECTION_BUCKET = {
+                MediaStore.Images.ImageColumns.BUCKET_ID,
+                MediaStore.Images.ImageColumns.BUCKET_DISPLAY_NAME,
+                "count(*) as photo_count"
+        };
+        // We want to order the albums by reverse chronological order. We abuse the
+        // "WHERE" parameter to insert a "GROUP BY" clause into the SQL statement.
+        // The template for "WHERE" parameter is like:
+        //    SELECT ... FROM ... WHERE (%s)
+        // and we make it look like:
+        //    SELECT ... FROM ... WHERE (1) GROUP BY 1,(2)
+        // The "(1)" means true. The "1,(2)" means the first two columns specified
+        // after SELECT. Note that because there is a ")" in the template, we use
+        // "(2" to match it.
+        String BUCKET_GROUP_BY =
+                "1) GROUP BY 1,(2";
+
+        // Get the base URI for the People table in the Contacts content provider.
+        Uri images = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+
+        Cursor cur = context.getContentResolver().query(
+                images, PROJECTION_BUCKET, BUCKET_GROUP_BY, null, "photo_count desc");
+
+        LinkedHashMap<String,String> imageBuckets = new LinkedHashMap<String, String>();
+        if (cur != null && cur.moveToFirst()) {
+            String bucket;
+            String id;
+            String bucketCount;
+            int bucketColumn = cur.getColumnIndex(
+                    MediaStore.Images.Media.BUCKET_DISPLAY_NAME);
+            int bucketIdColumn = cur.getColumnIndex(
+                    MediaStore.Images.Media.BUCKET_ID);
+            int bucketCountColumn = cur.getColumnIndex("photo_count");
+
+            do {
+                // Get the field values
+                bucket = cur.getString(bucketColumn);
+                id = cur.getString(bucketIdColumn);
+                bucketCount = cur.getString(bucketCountColumn);
+
+                Log.d(LOG_TAG, "Bucket=" + bucket + ", count=" + bucketCount);
+                imageBuckets.put(id, bucket + " (" + bucketCount + ")");
+                // Do something with the values.
+                //Log.i("Bucket", " bucket=" + bucket);
+            } while (cur.moveToNext());
+        }
+        closeCursor(cur);
+        return imageBuckets;
+    }
+
+    private void closeCursor(Cursor cursor) {
+        if (cursor != null && !cursor.isClosed()) {
+            cursor.close();
+        }
+    }
+
+}

--- a/src/fr/s13d/photobackup/PBMediaStoreQueries.java
+++ b/src/fr/s13d/photobackup/PBMediaStoreQueries.java
@@ -28,7 +28,6 @@ import android.provider.MediaStore;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Set;
-import java.util.SortedMap;
 
 import fr.s13d.photobackup.preferences.PBPreferenceFragment;
 
@@ -36,7 +35,6 @@ import fr.s13d.photobackup.preferences.PBPreferenceFragment;
 public class PBMediaStoreQueries {
 
     private static final String LOG_TAG = "PBMediaStoreQueries";
-    private static String where;
     private static Context context;
     private static final Uri uri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
     private final SharedPreferences prefs;
@@ -44,7 +42,6 @@ public class PBMediaStoreQueries {
 
     public PBMediaStoreQueries(Context theContext) {
         context = theContext;
-        HashMap<String, String> bucketNames = getAllBucketNames();
         prefs = PreferenceManager.getDefaultSharedPreferences(context);
     }
 
@@ -62,7 +59,7 @@ public class PBMediaStoreQueries {
                 Log.d(LOG_TAG, "Is selected bucket! Continuing");
                 return true;
             }
-        };
+        }
         Log.i(LOG_TAG, "Is not in selected buckets - Ignoring");
         return false;
     }
@@ -71,7 +68,7 @@ public class PBMediaStoreQueries {
         Cursor cursor = null;
         final String[] projection = new String[] { "_id", "_data", "date_added" };
         try {
-            cursor = context.getContentResolver().query(uri, projection, where, null, "date_added DESC");
+            cursor = context.getContentResolver().query(uri, projection, null, null, "date_added DESC");
         } catch(SecurityException e) {
             e.printStackTrace();
         }
@@ -141,15 +138,12 @@ public class PBMediaStoreQueries {
             int bucketCountColumn = cur.getColumnIndex("photo_count");
 
             do {
-                // Get the field values
                 bucket = cur.getString(bucketColumn);
                 id = cur.getString(bucketIdColumn);
                 bucketCount = cur.getString(bucketCountColumn);
 
                 Log.d(LOG_TAG, "Bucket=" + bucket + ", count=" + bucketCount);
                 imageBuckets.put(id, bucket + " (" + bucketCount + ")");
-                // Do something with the values.
-                //Log.i("Bucket", " bucket=" + bucket);
             } while (cur.moveToNext());
         }
         closeCursor(cur);

--- a/src/fr/s13d/photobackup/PBService.java
+++ b/src/fr/s13d/photobackup/PBService.java
@@ -19,6 +19,8 @@
 package fr.s13d.photobackup;
 
 import android.app.Service;
+import android.content.ContentResolver;
+import android.content.Context;
 import android.content.Intent;
 import android.database.ContentObserver;
 import android.net.Uri;
@@ -50,7 +52,9 @@ public class PBService extends Service implements PBMediaStoreInterface, PBMedia
         mediaStore.addInterface(this);
         mediaSender = new PBMediaSender(this);
         mediaSender.addInterface(this);
-        this.getApplicationContext().getContentResolver().registerContentObserver(
+        ContentResolver contentResolver = this.getApplicationContext().getContentResolver();
+
+        contentResolver.registerContentObserver(
                 MediaStore.Images.Media.EXTERNAL_CONTENT_URI, false, newMediaContentObserver);
 
         Log.i(LOG_TAG, "PhotoBackup service is created");
@@ -143,11 +147,15 @@ public class PBService extends Service implements PBMediaStoreInterface, PBMedia
         public void onChange(boolean selfChange, Uri uri) {
             super.onChange(selfChange);
             Log.i(LOG_TAG, "MediaContentObserver:onChange()");
+            Log.i(LOG_TAG, "Content-URI: " + uri);
 
             if (uri.toString().equals("content://media/external/images/media")) {
 
                 try {
                     final PBMedia media = mediaStore.getLastMediaInStore();
+                    if (media == null) {
+                        return;
+                    }
                     media.setState(PBMedia.PBMediaState.WAITING);
                     mediaSender.send(media, false);
                     //mediaStore.sync();

--- a/src/fr/s13d/photobackup/preferences/PBPreferenceFragment.java
+++ b/src/fr/s13d/photobackup/preferences/PBPreferenceFragment.java
@@ -178,7 +178,12 @@ public class PBPreferenceFragment extends PreferenceFragment
         Log.i(LOG_TAG, "onSharedPreferenceChanged: " + key);
         if (key.equals(PREF_SERVICE_RUNNING)) {
             startOrStopService(sharedPreferences);
-        } else if (key.equals(PREF_WIFI_ONLY) || key.equals(PREF_RECENT_UPLOAD_ONLY) || key.equals(PREF_BUCKETS)) {
+        } else if (key.equals(PREF_WIFI_ONLY) || key.equals(PREF_RECENT_UPLOAD_ONLY)) {
+            setSummaries();
+        } else if (key.equals(PREF_BUCKETS)) {
+            if (currentService != null) {
+                currentService.getMediaStore().sync();
+            }
             setSummaries();
         } else if (sharedPreferences == null) {
             Log.e(LOG_TAG, "Error: preferences == null");

--- a/src/fr/s13d/photobackup/preferences/PBPreferenceFragment.java
+++ b/src/fr/s13d/photobackup/preferences/PBPreferenceFragment.java
@@ -32,21 +32,30 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.preference.ListPreference;
+import android.preference.MultiSelectListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
 import android.preference.SwitchPreference;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
+import android.support.v4.content.LocalBroadcastManager;
+import android.text.TextUtils;
+import android.util.ArraySet;
 import android.webkit.URLUtil;
 import android.widget.Toast;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.zip.CheckedInputStream;
 
 import fr.s13d.photobackup.Log;
 import fr.s13d.photobackup.PBActivity;
 import fr.s13d.photobackup.PBMediaSender;
+import fr.s13d.photobackup.PBMediaStoreQueries;
 import fr.s13d.photobackup.PBService;
 import fr.s13d.photobackup.R;
 import fr.s13d.photobackup.interfaces.PBMediaSenderInterface;
@@ -76,6 +85,7 @@ public class PBPreferenceFragment extends PreferenceFragment
             currentService.getMediaStore().addInterface(self);
             updateUploadJournalPreference(); // update journal serverKeys number
             Log.i(LOG_TAG, "Connected to service");
+            fillBuckets();
         }
 
         public void onServiceDisconnected(ComponentName className) {
@@ -89,7 +99,8 @@ public class PBPreferenceFragment extends PreferenceFragment
     public static final String PREF_SERVER = "PREF_SERVER";
     public static final String PREF_WIFI_ONLY = "PREF_WIFI_ONLY";
     public static final String PREF_RECENT_UPLOAD_ONLY = "PREF_RECENT_UPLOAD_ONLY";
-
+    public static final String PREF_BUCKETS = "PREF_BUCKETS";
+    private HashMap<String, String> bucketNames;
 
     //////////////////
     // Constructors //
@@ -111,8 +122,23 @@ public class PBPreferenceFragment extends PreferenceFragment
             preferencesEditor.apply();
         }
         migratePreferences();
-
         addPreferencesFromResource(R.xml.preferences);
+
+    }
+
+    private void fillBuckets() {
+        HashMap<String, String> buckets = currentService.getMediaStore().getQueries().getAllBucketNames();
+        this.bucketNames = buckets;
+
+        CharSequence[] entries = buckets.values().toArray(new CharSequence[buckets.size()]);
+        CharSequence[] entryValues = buckets.keySet().toArray(new CharSequence[buckets.size()]);
+
+        MultiSelectListPreference lp = (MultiSelectListPreference)findPreference("PREF_BUCKETS");
+        lp.setEntries(entries);
+        lp.setEnabled(true);
+        lp.setEntryValues(entryValues);
+
+        setSummaries();
     }
 
 
@@ -152,13 +178,8 @@ public class PBPreferenceFragment extends PreferenceFragment
         Log.i(LOG_TAG, "onSharedPreferenceChanged: " + key);
         if (key.equals(PREF_SERVICE_RUNNING)) {
             startOrStopService(sharedPreferences);
-
-        } else if (key.equals(PREF_WIFI_ONLY)) {
+        } else if (key.equals(PREF_WIFI_ONLY) || key.equals(PREF_RECENT_UPLOAD_ONLY) || key.equals(PREF_BUCKETS)) {
             setSummaries();
-
-        } else if (key.equals(PREF_RECENT_UPLOAD_ONLY)) {
-            setSummaries();
-
         } else if (sharedPreferences == null) {
             Log.e(LOG_TAG, "Error: preferences == null");
         }
@@ -200,6 +221,23 @@ public class PBPreferenceFragment extends PreferenceFragment
 
 
     private void setSummaries() {
+
+        String buckets = "";
+        Set<String> selectedBuckets = preferences.getStringSet(PREF_BUCKETS, null);
+        if (selectedBuckets != null && bucketNames != null) {
+            ArrayList<String> selectedBucketNames = new ArrayList<String>();
+            for(String entry: selectedBuckets) {
+                String oneName = bucketNames.get(entry);
+                if (oneName != null) {
+                    selectedBucketNames.add(oneName);
+                }
+            }
+            buckets = TextUtils.join(", ", selectedBucketNames);
+        }
+        MultiSelectListPreference bucketPreference = (MultiSelectListPreference)findPreference(PREF_BUCKETS);
+        bucketPreference.setSummary(buckets);
+
+
         final String wifiOnly = preferences.getString(PREF_WIFI_ONLY,
                 getResources().getString(R.string.only_wifi_default)); // default
         final ListPreference wifiPreference = (ListPreference) findPreference(PREF_WIFI_ONLY);

--- a/src/fr/s13d/photobackup/preferences/PBServerPreferenceFragment.java
+++ b/src/fr/s13d/photobackup/preferences/PBServerPreferenceFragment.java
@@ -118,7 +118,6 @@ public class PBServerPreferenceFragment extends PreferenceFragment
         } else if (sharedPreferences == null) {
             Log.e(LOG_TAG, "Error: preferences == null");
         }
-
     }
 
 
@@ -146,7 +145,6 @@ public class PBServerPreferenceFragment extends PreferenceFragment
             Preference pref = findPreference(param);
             screen.removePreference(pref);
         }
-
     }
 
 


### PR DESCRIPTION
I've added a button to initiate a new upload of all failed media.
- Hovering button at the bottom (is there a better place?)
- Alert box, just copypaste from manual upload
- Missing fr/cz translations

As now, this commit depends on some of the other PRs before, cherry-picking lead to some conflicts. 
I might try to extract it, if it is necessary, but would rather wait until the other changes are done.

The relevant changes are in 1ec2382a61faafafe8d1ace788b2ff529d0bfb28
![screenshot_20160521-161757](https://cloud.githubusercontent.com/assets/147175/15447289/6260dcb6-1f70-11e6-8e7e-18564aa3ae0d.png)
