### PR TITLE
On Wifi send

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -6,6 +6,7 @@
  	<uses-permission android:name="android.permission.INTERNET" />
  	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 
     <application
         android:name="fr.s13d.photobackup.PBApplication"
@@ -30,12 +31,18 @@
 
 		<service android:name=".PBService" android:exported="false" />
 
-		<!-- Declaring broadcast receiver for BOOT_COMPLETED event -->
-    	<receiver android:name=".PBBootBroadcastReceiver">
-	    	<intent-filter>
-        		<action android:name="android.intent.action.BOOT_COMPLETED" />
-    		</intent-filter>
-		</receiver>
+      <!-- Declaring broadcast receiver for BOOT_COMPLETED event -->
+      <receiver android:name=".PBBootBroadcastReceiver">
+        <intent-filter>
+          <action android:name="android.intent.action.BOOT_COMPLETED" />
+        </intent-filter>
+      </receiver>
+      <!-- Declaring broadcast receiver for BOOT_COMPLETED event -->
+      <receiver android:name=".PBWifiBroadcastReceiver">
+        <intent-filter>
+          <action android:name="android.net.conn.CONNECTIVITY_CHANGE" />
+        </intent-filter>
+      </receiver>
 
     </application>
 

--- a/src/fr/s13d/photobackup/PBMedia.java
+++ b/src/fr/s13d/photobackup/PBMedia.java
@@ -61,7 +61,9 @@ public class PBMedia implements Serializable {
         return "PBMedia: " + this.path;
     }
 
-
+    public long age() {
+        return System.currentTimeMillis() / 1000 - getDateAdded();
+    }
     /////////////////////////////////////////
     // Getters/Setters are the Java fun... //
     /////////////////////////////////////////

--- a/src/fr/s13d/photobackup/PBMediaSender.java
+++ b/src/fr/s13d/photobackup/PBMediaSender.java
@@ -102,6 +102,7 @@ public class PBMediaSender {
         Boolean uploadRecentOnly = uploadRecentOnlyString.equals(context.getResources().getString(R.string.only_recent_upload));
         Boolean recentPicture = (System.currentTimeMillis() / 1000 - media.getDateAdded()) < 600;
 
+        Log.i(LOG_TAG, "Connectivity: onWifi=" + onWifi.toString() + ", wifiOnly=" + wifiOnly.toString() + ", recentPicture=" + recentPicture.toString());
         // test to send or not
         if (manual || (!wifiOnly || onWifi) && (!uploadRecentOnly || recentPicture)) {
             sendMedia(media);

--- a/src/fr/s13d/photobackup/PBMediaStore.java
+++ b/src/fr/s13d/photobackup/PBMediaStore.java
@@ -70,7 +70,6 @@ public class PBMediaStore {
         interfaces.add(storeInterface);
     }
 
-
     public void close() {
         if (syncTask != null) {
             syncTask.cancel(true);

--- a/src/fr/s13d/photobackup/PBService.java
+++ b/src/fr/s13d/photobackup/PBService.java
@@ -98,11 +98,15 @@ public class PBService extends Service implements PBMediaStoreInterface, PBMedia
         if (mediaStore != null) {
             for (PBMedia media : mediaStore.getMedias()) {
                 if (media.getState() != PBMedia.PBMediaState.SYNCED) {
-                    mediaSender.send(media, false);
+                    sendMedia(media, false);
                     break;
                 }
             }
         }
+    }
+
+    public void sendMedia(PBMedia media, boolean manual) {
+        mediaSender.send(media, manual);
     }
 
 

--- a/src/fr/s13d/photobackup/PBWifiBroadcastReceiver.java
+++ b/src/fr/s13d/photobackup/PBWifiBroadcastReceiver.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2013-2015
+ *
+ * This file is part of PhotoBackup.
+ *
+ * PhotoBackup is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PhotoBackup is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package fr.s13d.photobackup;
+
+import android.content.BroadcastReceiver;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.content.SharedPreferences;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+import android.net.wifi.WifiManager;
+import android.os.IBinder;
+import android.preference.PreferenceManager;
+
+
+import java.util.List;
+
+import fr.s13d.photobackup.preferences.PBPreferenceFragment;
+import fr.s13d.photobackup.preferences.PBServerListPreference;
+
+public class PBWifiBroadcastReceiver extends BroadcastReceiver {
+    private static final String LOG_TAG = "PBWifiBroadcastReceiver";
+    private static boolean alreadyFired = false;
+
+    // binding
+ 
+    @Override
+	public void onReceive(final Context context, final Intent intent) {
+        if (alreadyFired) {
+            return;
+        }
+		WifiManager wifiManager = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
+
+
+		final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+		String wifiOnlyString = preferences.getString(PBPreferenceFragment.PREF_WIFI_ONLY,
+				context.getResources().getString(R.string.only_wifi_default));
+		Boolean wifiOnly = wifiOnlyString.equals(context.getResources().getString(R.string.only_wifi));
+        Log.i(LOG_TAG, "New Intent: action=" + intent.getAction() + ", type=" + intent.getType());
+		if (wifiManager.isWifiEnabled() && wifiOnly) {
+
+            Log.i(LOG_TAG, "Wifi comes back, checking Service");
+            IBinder binder = peekService(context, new Intent(context, PBService.class));
+            if(binder == null) {
+                return;
+            }
+            PBService service = ((PBService.Binder) binder).getService();
+            if(service == null) {
+                return;
+            }
+            alreadyFired = true;
+            Log.i(LOG_TAG, "Media Store: " + service.getMediaStore());
+
+            PBMediaStore mediaStore = service.getMediaStore();
+            if (mediaStore == null) {
+                return;
+            }
+            List<PBMedia> medias = mediaStore.getMedias();
+            Log.i(LOG_TAG, "media_count=" + medias.size());
+
+            for (PBMedia media : mediaStore.getMedias()) {
+                if (media.age() < 3600 * 24 * 7 && media.getState() != PBMedia.PBMediaState.SYNCED) {
+                    Log.i(LOG_TAG, "Notify to send " + media.getPath());
+                    service.sendMedia(media, true);
+                }
+            }
+		}
+	}
+}

--- a/src/fr/s13d/photobackup/PBWifiBroadcastReceiver.java
+++ b/src/fr/s13d/photobackup/PBWifiBroadcastReceiver.java
@@ -42,24 +42,24 @@ public class PBWifiBroadcastReceiver extends BroadcastReceiver {
     private static long lastFiredOn = 0;
 
     // binding
- 
+
     @Override
-	public void onReceive(final Context context, final Intent intent) {
+    public void onReceive(final Context context, final Intent intent) {
         final long now = System.currentTimeMillis() / 1000;
         // Receiver should only live a short time, but the onReceive is called multiple times
         // Only call that once every 10 minutes
         if (now - lastFiredOn < 600) {
             return;
         }
-		WifiManager wifiManager = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
+        WifiManager wifiManager = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
 
 
-		final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-		String wifiOnlyString = preferences.getString(PBPreferenceFragment.PREF_WIFI_ONLY,
-				context.getResources().getString(R.string.only_wifi_default));
-		Boolean wifiOnly = wifiOnlyString.equals(context.getResources().getString(R.string.only_wifi));
+        final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        String wifiOnlyString = preferences.getString(PBPreferenceFragment.PREF_WIFI_ONLY,
+                context.getResources().getString(R.string.only_wifi_default));
+        Boolean wifiOnly = wifiOnlyString.equals(context.getResources().getString(R.string.only_wifi));
         Log.i(LOG_TAG, "New Intent: action=" + intent.getAction() + ", type=" + intent.getType());
-		if (wifiManager.isWifiEnabled() && wifiOnly) {
+        if (wifiManager.isWifiEnabled() && wifiOnly) {
 
             Log.i(LOG_TAG, "Wifi comes back, checking Service");
             IBinder binder = peekService(context, new Intent(context, PBService.class));
@@ -87,6 +87,6 @@ public class PBWifiBroadcastReceiver extends BroadcastReceiver {
                     service.sendMedia(media, true);
                 }
             }
-		}
-	}
+        }
+    }
 }


### PR DESCRIPTION
- New Permission: access wifi state; needed anyway for the issue with wifi SSID
- Wifi Receiver waits for active wifi connection, then sends all unsaved images of last 7 days.

Potential cleanups:
- the getAge and age from the other PR
- telling the service to send some unsaved images is almost the same like the RetryAll button, that could be unified, best in the service so it is async handled and queued.
