### PR TITLE
Android automatic refactor - Recycle

### DIFF
--- a/app/src/main/java/fr/s13d/photobackup/media/PBMediaStore.java
+++ b/app/src/main/java/fr/s13d/photobackup/media/PBMediaStore.java
@@ -83,13 +83,19 @@ public class PBMediaStore {
         final Cursor cursor = cr.query(backupVideos ? videosUri : imagesUri, null, null, null, DATE_ADDED_DESC);
         if (cursor == null || !cursor.moveToFirst()) {
             Log.d(LOG_TAG, "Media cursor is null or empty.");
-            return null;
+            if (cursor != null) {
+				cursor.close();
+			}
+			return null;
         }
 
         final int bucketId = cursor.getColumnIndex(MediaStore.Images.Media.BUCKET_ID);
         if (!backupVideos && !isBucketSelected(cursor.getString(bucketId))) {
             Log.d(LOG_TAG, "Media not in selected buckets.");
-            return null;
+            if (cursor != null) {
+				cursor.close();
+			}
+			return null;
         }
 
         final PBMedia media = new PBMedia(cursor);


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "Recycle".

Some resources (e.g., ```Cursor``` instances) should be closed when they are no longer necessary. 

I have made a previous validation of the changes and they seem correct.
Please consider them and let me know if you agree with them.

Best,
Luis